### PR TITLE
Factor out ImageDecoder until segmentation faults are resolved

### DIFF
--- a/py/examples/camera_client/requirements.txt
+++ b/py/examples/camera_client/requirements.txt
@@ -1,4 +1,3 @@
 farm-ng-amiga
 opencv-python==4.6.0.66
 numpy==1.23.2
-kornia_rs==0.0.8

--- a/py/examples/file_converter/main.py
+++ b/py/examples/file_converter/main.py
@@ -23,7 +23,6 @@ from farm_ng.core.events_file_reader import build_events_dict
 from farm_ng.core.events_file_reader import EventLogPosition
 from farm_ng.core.events_file_reader import EventsFileReader
 from farm_ng.oak import oak_pb2
-from kornia_rs import ImageDecoder
 from tqdm import tqdm
 
 
@@ -67,20 +66,16 @@ def main(
     # create a video writer to write the video
     video_writer: cv2.VideoWriter | None = None
 
-    # instantiate the image decoder
-    image_decoder = ImageDecoder()
-
     event_log: EventLogPosition
     for event_log in tqdm(camera_events):
         # parse the message
         sample: oak_pb2.OakFrame = event_log.read_message()
 
         # decode image
-        img: np.ndarray = cv2.cvtColor(np.from_dlpack(image_decoder.decode(sample.image_data)), cv2.COLOR_RGB2BGR)
-
+        img = cv2.imdecode(np.frombuffer(sample.image_data, dtype="uint8"), cv2.IMREAD_UNCHANGED)
         if view_name == "disparity":
             disparity_scale: int = max(1, int(disparity_scale))
-            img = cv2.applyColorMap(img * disparity_scale, cv2.COLORMAP_HOT)
+            img = cv2.applyColorMap(img * disparity_scale, cv2.COLORMAP_JET)
 
         # show image
         cv2.imshow(topic_name, img)

--- a/py/examples/file_converter/requirements.txt
+++ b/py/examples/file_converter/requirements.txt
@@ -2,4 +2,3 @@ farm-ng-amiga
 opencv-python
 numpy
 tqdm
-kornia_rs==0.0.8

--- a/py/examples/file_reader/requirements.txt
+++ b/py/examples/file_reader/requirements.txt
@@ -1,4 +1,3 @@
 farm-ng-amiga
 opencv-python
 numpy
-kornia_rs==0.0.8


### PR DESCRIPTION
Fairly regularly (and more common with the `/left` & `/right` image streams / playback from logs), the image decoding using `np.from_dlpack(image_decoder.decode(message.image_data))` causes a segmentation fault. This is true for a live stream with the camera client and for the file playback.

It is definitely much faster, but we should revert to cv2 decoding until it is more stable