### PR TITLE
proto, grpcio version lock

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,8 +26,8 @@ setup_requires =
     # temporary until released
     farm-ng-core
 install_requires =
-    protobuf
-    grpcio
+    protobuf==5.27.2
+    grpcio==1.64.1
     # temporary until released
     farm_ng_core
 tests_require =


### PR DESCRIPTION
lock protobuf and grpcio on last known stable versions with our images. 5.28+ is throwing segmentation errors.