### PR TITLE
Fix CI breakage on ubuntu-latest

### DIFF
--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -14,8 +14,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest] # ubuntu only for now macos-latest, windows-latest]
-        python-version: [3.8] # ubuntu 20.04, python 3.8 is our current supported target
+        # Ubuntu with python 3.8 is our current supported target, matching
+        # AmigaOS on the Brain.
+        os: [ubuntu-22.04]
+        python-version: [3.8]
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   # TODO: fix mypy for protobufs
   # mypy:
-  #   runs-on: [ubuntu-latest]
+  #   runs-on: [ubuntu-22.04]
   #   steps:
   #   - uses: actions/checkout@v3
   #   - name: Install dependencies
@@ -20,7 +20,7 @@ jobs:
   #     run: mypy
 
   pre-commit-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   pypi:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@master
     - uses: actions/setup-python@v2


### PR DESCRIPTION
For now, pin our CI jobs to `ubuntu-22.04`. This is the final GitHub runner ubuntu image with Python 3.8 (our current supported target, matching AmigaOS on the Brain) baked in.

Part of SWE-531.