### PR TITLE
Lock req versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ requires = [
     "setuptools",
     "wheel",
     "farm-ng-core",
+    "farm-ng-package",
     "protobuf<=5.27.5",
     "grpcio-tools==1.64.1",
     ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,8 @@ profile = "black"
 [build-system]
 requires = [
     "setuptools",
+    "wheel",
     "farm-ng-package",
+    "farm-ng-core",
     ]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ profile = "black"
 requires = [
     "setuptools",
     "wheel",
-    "farm-ng-package",
     "farm-ng-core",
+    "protobuf<=5.27.5",
+    "grpcio-tools==1.64.1",
     ]
 build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,10 +21,7 @@ classifiers =
 
 [options]
 python_requires = >=3.6
-setup_requires =
-    wheel
-    # temporary until released
-    farm-ng-core
+
 install_requires =
     grpcio
     grpcio-tools

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,6 @@ python_requires = >=3.6
 
 install_requires =
     grpcio
-    grpcio-tools
     # temporary until seg fault issue with protobuf>=5.28 is resolved in Brain's Image
     protobuf<=5.27.5
     # temporary until released

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = farm_ng_amiga
-version = 2.3.3-dev
+version = 2.3.3
 description = Amiga development kit for third party hardware or software extensions
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -26,8 +26,9 @@ setup_requires =
     # temporary until released
     farm-ng-core
 install_requires =
-    protobuf
-    grpcio
+    grpcio==1.56.2
+    grpcio-tools==1.56.2
+    protobuf==4.23.4
     # temporary until released
     farm_ng_core
 tests_require =

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,9 +26,9 @@ setup_requires =
     # temporary until released
     farm-ng-core
 install_requires =
-    grpcio==1.56.2
-    grpcio-tools==1.56.2
-    protobuf==4.23.4
+    grpcio==
+    grpcio-tools
+    protobuf==5.27.5
     # temporary until released
     farm_ng_core
 tests_require =

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ setup_requires =
 install_requires =
     grpcio==
     grpcio-tools
-    protobuf==5.27.5
+    protobuf<=5.27.5
     # temporary until released
     farm_ng_core
 tests_require =

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ setup_requires =
     # temporary until released
     farm-ng-core
 install_requires =
-    grpcio==
+    grpcio
     grpcio-tools
     # temporary until seg fault issue with protobuf>=5.28 is resolved in Brain's Image
     protobuf<=5.27.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ setup_requires =
 install_requires =
     grpcio==
     grpcio-tools
+    # temporary until seg fault issue with protobuf>=5.28 is resolved in Brain's Image
     protobuf<=5.27.5
     # temporary until released
     farm_ng_core


### PR DESCRIPTION
separated build and install time requirements. Lock protobuf and grpcio versions to latest known stable versions.