### PR TITLE
Fix the PyPI release build to use Python 3.8

### DIFF
--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -16,11 +16,15 @@ jobs:
       matrix:
         # Ubuntu with python 3.8 is our current supported target, matching
         # AmigaOS on the Brain.
+        # Note also that we fix grpcio-tools==1.64.1 at build time in
+        # pyproject.toml to control the protoc version and resulting gencode
+        # version of the generated protobuf code we package. v1.64.1 is
+        # incompatible with recent Python versions, at least 3.13+.
         os: [ubuntu-22.04]
         python-version: [3.8]
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
 
       - name: set PY
         run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -9,7 +9,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@master
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v5
+      with:
+        # Match ci_python.yml. See notes on Python version there.
+        python-version: '3.8'
     - name: Install dependencies
       run: python3 -m pip install --upgrade setuptools wheel
     - name: Compile project


### PR DESCRIPTION
For CI consistency and compatibility with `grpcio-tools` v1.64.1.

Related to SWE-427.