### PR TITLE
Use build instead of invoking setup.py directly

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -14,11 +14,11 @@ jobs:
         # Match ci_python.yml. See notes on Python version there.
         python-version: '3.8'
     - name: Install dependencies
-      run: python3 -m pip install --upgrade setuptools wheel
+      run: python3 -m pip install --upgrade setuptools wheel build
     - name: Compile project
       run: python3 -m pip install -e .
     - name: Build distribution package
-      run: python3 setup.py sdist bdist_wheel
+      run: python3 -m build
     - name: Publish distribution 📦 to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,9 @@ profile = "black"
 requires = [
     "setuptools",
     "wheel",
-    "farm-ng-core",
-    "farm-ng-package",
     "protobuf<=5.27.5",
     "grpcio-tools==1.64.1",
+    "farm-ng-core",
+    "farm-ng-package",
     ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This is the modern approach. Most critically, it uses an isolated venv containing the build-time dependencies such as farm-ng-package, which setup.py does not. For gory details, see
https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html

Part of SWE-427.